### PR TITLE
Add build instructions and placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Consentus
+
+This repository contains the compiled `main.js` file that powers the demo in `index.html`. The original JavaScript/React source files used to build `main.js` are not included. If you have access to those sources, place them in the `src/` directory.
+
+## Build
+
+Install dependencies once with `npm install` (requires Node.js). To rebuild `main.js` from the source files in `src/`, run:
+
+```bash
+npm run build
+```
+
+The build script uses Browserify and Babel to bundle React components from `src/index.js` and its imports into `main.js`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "consentus",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "browserify src/index.js -t [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] -o main.js",
+    "test": "echo \"No tests specified\""
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.0",
+    "@babel/preset-env": "^7.22.0",
+    "@babel/preset-react": "^7.22.0",
+    "babelify": "^10.0.0",
+    "browserify": "^17.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-bootstrap": "^2.10.0"
+  }
+}

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,4 @@
+# Source code
+
+The original React and JavaScript source files used to generate `../main.js` are not included in this repository.
+If you have access to the source, place the files in this directory and run `npm run build` to generate `main.js`.

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const App = () => <div>Consentus placeholder</div>;
+
+ReactDOM.render(<App />, document.getElementById('react-main-mount'));


### PR DESCRIPTION
## Summary
- add README with build instructions
- provide package.json and placeholder source files
- ignore `node_modules`

## Testing
- `npm test`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68415f2d4e548320b2ab761ce86a5f8c